### PR TITLE
fix: folderpath inconsistency for hugging face binding

### DIFF
--- a/hugging_face/__init__.py
+++ b/hugging_face/__init__.py
@@ -38,7 +38,7 @@ class HuggingFace(LLMBinding):
     file_extension='*'
     def __init__(self, 
                 config: LOLLMSConfig, 
-                lollms_paths: LollmsPaths = LollmsPaths(), 
+                lollms_paths: LollmsPaths = None, 
                 installation_option:InstallOption=InstallOption.INSTALL_IF_NECESSARY) -> None:
         """
         Initialize the Binding.
@@ -49,7 +49,8 @@ class HuggingFace(LLMBinding):
             installation_option (InstallOption, optional): The installation option for LOLLMS. Defaults to InstallOption.INSTALL_IF_NECESSARY.
         """
         # Initialization code goes here
-
+        if lollms_paths is None:
+            lollms_paths = LollmsPaths()
         binding_config = TypedConfig(
             ConfigTemplate([
                 {"name":"gpu_layers","type":"int","value":20, "min":0},


### PR DESCRIPTION
This pull request addresses the issue of inconsistent folder paths in the lollms application when switching bindings. The root cause of this problem is the evaluation behavior of Python function default parameters, where they are evaluated only once during function definition.

I only fixed the hugging face binding, this PR purely for reference, and asking a confirmation regarding what I did. 
Just in case my fix will cause unexpected issue I'm unaware of, so I can prevent that from happening on my side too.

Reference:
[Stack Overflow: Python function default parameter is evaluated only once](https://stackoverflow.com/questions/13087344/python-function-default-parameter-is-evaluated-only-once)