### PR TITLE
Fixed a bug that made every generation with llama.cpp full determinis…

### DIFF
--- a/llama_cpp_official/__init__.py
+++ b/llama_cpp_official/__init__.py
@@ -73,8 +73,6 @@ class LLAMACPP(LLMBinding):
         
     def build_model(self):
         seed = self.config["seed"]
-        if seed<0:
-            seed = 0
 
         # if seed <=0:
         #    seed = random.randint(1, 2**31)


### PR DESCRIPTION
…tic, when meaning to be random.

Llama.cpp convention for random seed is -1 and not 0. 0 is a valid seed and the previous code was just making any output be deterministic for a given prompt.